### PR TITLE
Fix crash in AddressInputHelper

### DIFF
--- a/cpp/src/address_input_helper.cc
+++ b/cpp/src/address_input_helper.cc
@@ -16,6 +16,7 @@
 
 #include <libaddressinput/address_data.h>
 #include <libaddressinput/address_field.h>
+#include <libaddressinput/address_metadata.h>
 #include <libaddressinput/preload_supplier.h>
 #include <libaddressinput/util/basictypes.h>
 
@@ -167,7 +168,13 @@ void AddressInputHelper::CheckChildrenForPostCodeMatches(
     node->parent = parent;
     node->rule = rule;
 
-    // If there are children, check them too.
+    // If children are not used, do not check them.
+    if (!IsFieldUsed(static_cast<AddressField>(lookup_key.GetDepth() + 1),
+                     address.region_code)) {
+      return;
+    }
+
+    // If children are used and present, check the children.
     for (std::vector<std::string>::const_iterator child_it =
              rule->GetSubKeys().begin();
          child_it != rule->GetSubKeys().end(); ++child_it) {

--- a/cpp/src/address_input_helper.cc
+++ b/cpp/src/address_input_helper.cc
@@ -168,19 +168,16 @@ void AddressInputHelper::CheckChildrenForPostCodeMatches(
     node->parent = parent;
     node->rule = rule;
 
-    // If children are not used, do not check them.
-    if (!IsFieldUsed(static_cast<AddressField>(lookup_key.GetDepth() + 1),
-                     address.region_code)) {
-      return;
-    }
-
-    // If children are used and present, check the children.
-    for (std::vector<std::string>::const_iterator child_it =
-             rule->GetSubKeys().begin();
-         child_it != rule->GetSubKeys().end(); ++child_it) {
-      LookupKey child_key;
-      child_key.FromLookupKey(lookup_key, *child_it);
-      CheckChildrenForPostCodeMatches(address, child_key, node, hierarchy);
+    if (IsFieldUsed(LookupKey::kHierarchy[lookup_key.GetDepth() + 1],
+                    address.region_code)) {
+      // If children are used and present, check them too.
+      for (std::vector<std::string>::const_iterator child_it =
+               rule->GetSubKeys().begin();
+           child_it != rule->GetSubKeys().end(); ++child_it) {
+        LookupKey child_key;
+        child_key.FromLookupKey(lookup_key, *child_it);
+        CheckChildrenForPostCodeMatches(address, child_key, node, hierarchy);
+      }
     }
   }
 }

--- a/cpp/test/address_input_helper_test.cc
+++ b/cpp/test/address_input_helper_test.cc
@@ -238,6 +238,19 @@ TEST_F(AddressInputHelperTest, AddressWithInvalidOrMissingRegionCode) {
   EXPECT_EQ(expected, address);
 }
 
+TEST_F(AddressInputHelperTest, RegionWithUnusedAdminAreaNames) {
+  AddressData address;
+  address.region_code = "CH";
+  address.postal_code = "1111";
+  address.language_code = "de-CH";
+
+  // Administrative area should not be filled because it's not used. Locality
+  // should not be filled because there's no data for it.
+  AddressData expected = address;
+  FillAddress(&address);
+  EXPECT_EQ(expected, address);
+}
+
 class AddressInputHelperMockDataTest : public testing::Test {
  protected:
   AddressInputHelperMockDataTest()


### PR DESCRIPTION
if you pass an a Switzerland address with postal code "1111" to AddressInputHelper::FillAddress(), then libaddressinput will crash. This is because the data for Switzerland contains administrative area names, but its address format does use the administrative area field. The first patch adds a unit test that fails without the fix. The second patch is the fix.