### PR TITLE
Update README to gradle connectedAndroidTest.

### DIFF
--- a/android/README
+++ b/android/README
@@ -38,7 +38,7 @@ $ gradle build
 With an Android emulator running or an Android device connected, the following
 command line then builds the library and runs the tests:
 
-$ gradle connectedInstrumentTest
+$ gradle connectedAndroidTest
 
 The test runner logs to the system log, which can be viewed using logcat:
 


### PR DESCRIPTION
As of plugin version 0.9 the task name is now connectedAndroidTest
instead of the old connectedInstrumentTest.