### PR TITLE
Add missing license headers

### DIFF
--- a/android/src/main/java/com/android/i18n/addressinput/AndroidAsyncRequestApi.java
+++ b/android/src/main/java/com/android/i18n/addressinput/AndroidAsyncRequestApi.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2015 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.android.i18n.addressinput;
 
 import com.google.i18n.addressinput.common.AsyncRequestApi;

--- a/common/src/main/java/com/google/i18n/addressinput/common/AsyncRequestApi.java
+++ b/common/src/main/java/com/google/i18n/addressinput/common/AsyncRequestApi.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2015 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.google.i18n.addressinput.common;
 
 /**

--- a/common/src/test/java/com/google/i18n/addressinput/testing/InMemoryAsyncRequest.java
+++ b/common/src/test/java/com/google/i18n/addressinput/testing/InMemoryAsyncRequest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2015 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.google.i18n.addressinput.testing;
 
 import com.google.i18n.addressinput.common.AsyncRequestApi;


### PR DESCRIPTION
Chromium requires license headers for all files in third party libraries. Chromium cannot use the newest version of libaddressinput without these changes. Chromium build log:

'third_party/libaddressinput/src/android/src/main/java/com/android/i18n/addressinput/AndroidAsyncRequestApi.java' has non-whitelisted license 'UNKNOWN'
'third_party/libaddressinput/src/common/src/test/java/com/google/i18n/addressinput/testing/InMemoryAsyncRequest.java' has non-whitelisted license 'UNKNOWN'
'third_party/libaddressinput/src/common/src/main/java/com/google/i18n/addressinput/common/AsyncRequestApi.java' has non-whitelisted license 'UNKNOWN'