### PR TITLE
Enables compiling address_data_test.cc on iOS

### DIFF
--- a/cpp/test/address_data_test.cc
+++ b/cpp/test/address_data_test.cc
@@ -196,18 +196,21 @@ TEST(AddressDataTest, TestEquals) {
 
 TEST(AddressDataTest, GetFieldValueInvalid) {
   AddressData address;
-  ASSERT_DEATH(address.GetFieldValue(STREET_ADDRESS), "ssertion.*failed");
+  ASSERT_DEATH_IF_SUPPORTED(address.GetFieldValue(STREET_ADDRESS),
+                            "ssertion.*failed");
 }
 
 TEST(AddressDataTest, GetVectorFieldValueInvalid) {
   AddressData address;
-  ASSERT_DEATH(address.GetRepeatedFieldValue(COUNTRY), "ssertion.*failed");
+  ASSERT_DEATH_IF_SUPPORTED(address.GetRepeatedFieldValue(COUNTRY),
+                            "ssertion.*failed");
 }
 
 TEST(AddressDataTest, IsFieldEmptyInvalid) {
   static const AddressField invalid_field = static_cast<AddressField>(-1);
   AddressData address;
-  ASSERT_DEATH(address.IsFieldEmpty(invalid_field), "ssertion.*failed");
+  ASSERT_DEATH_IF_SUPPORTED(address.IsFieldEmpty(invalid_field),
+                            "ssertion.*failed");
 }
 
 #endif  // NDEBUG


### PR DESCRIPTION
The test uses ASSERT_DEATH which cannot be supported on iOS.

ASSERT_DEATH checks that the process exits with a non-zero return code.
This requires forking to run the test in a sub-process and checking the
return code of that child process. On iOS, all applications are single
process (this is a restriction imposed by the OS) which means that
ASSERT_DEATH cannot be implemented.

Google Tests offers another macro ASSERT_DEATH_IF_SUPPORTED that should
be used instead. It will not test anything on iOS, but will allow
compilation to succeed (ASSERT_DEATH is not defined on platforms that do
not support ASSERT_DEATH on purpose, so that cross-platform wanting to
use that class of tests gets a compilation error on platforms that do
not support them).

http://crbug.com/595645