### PR TITLE
Enable installing the library on an attached Android device.

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -26,6 +26,9 @@ buildscript {
 
 apply plugin: 'java'
 
+sourceCompatibility = '1.7'
+targetCompatibility = '1.7'
+
 tasks.withType(JavaCompile) {
     options.encoding = 'UTF-8'
 }


### PR DESCRIPTION
If you run `gradle clean build install` without this patch, the install
step will fail with a "bad class file magic" error. This patch fixes the
issue by specifying source and target to be compatible with Java 1.7.