### PR TITLE
(AUTOMATIC) opensource update

### DIFF
--- a/android/src/main/java/com/android/i18n/addressinput/AddressWidget.java
+++ b/android/src/main/java/com/android/i18n/addressinput/AddressWidget.java
@@ -142,6 +142,7 @@ public class AddressWidget implements AdapterView.OnItemSelectedListener {
     localityLabelMap.put("city", R.string.i18n_locality_label);
     localityLabelMap.put("district", R.string.i18n_district);
     localityLabelMap.put("post_town", R.string.i18n_post_town);
+    localityLabelMap.put("suburb", R.string.i18n_suburb);
     LOCALITY_LABELS = Collections.unmodifiableMap(localityLabelMap);
 
     Map<String, Integer> sublocalityLabelMap = new HashMap<String, Integer>(2);

--- a/common/src/main/java/com/google/i18n/addressinput/common/RegionDataConstants.java
+++ b/common/src/main/java/com/google/i18n/addressinput/common/RegionDataConstants.java
@@ -27,20 +27,20 @@ public final class RegionDataConstants {
 
   private static Map<String, String> createMap() {
     TreeMap<String, String> map = new TreeMap<String, String>();
-    map.put("AC", "{\"name\":\"ASCENSION ISLAND\"}");
+    map.put("AC", "{\"name\":\"ASCENSION ISLAND\",\"fmt\":\"%N%n%O%n%A%n%C%n%Z\"}");
     map.put("AD", "{\"name\":\"ANDORRA\",\"lang\":\"ca\",\"languages\":\"ca\",\"fmt\":\"%N%n%O%n%A%n%Z %C\"}");
     map.put("AE", "{\"name\":\"UNITED ARAB EMIRATES\",\"lang\":\"ar\",\"languages\":\"ar\",\"lfmt\":\"%N%n%O%n%A%n%S\",\"fmt\":\"%N%n%O%n%A%n%S\",\"require\":\"AS\",\"state_name_type\":\"emirate\"}");
-    map.put("AF", "{\"name\":\"AFGHANISTAN\"}");
+    map.put("AF", "{\"name\":\"AFGHANISTAN\",\"fmt\":\"%N%n%O%n%A%n%C%n%Z\"}");
     map.put("AG", "{\"name\":\"ANTIGUA AND BARBUDA\",\"require\":\"A\"}");
-    map.put("AI", "{\"name\":\"ANGUILLA\"}");
-    map.put("AL", "{\"name\":\"ALBANIA\"}");
+    map.put("AI", "{\"name\":\"ANGUILLA\",\"fmt\":\"%N%n%O%n%A%n%C%n%Z\"}");
+    map.put("AL", "{\"name\":\"ALBANIA\",\"fmt\":\"%N%n%O%n%A%n%Z%n%C\"}");
     map.put("AM", "{\"name\":\"ARMENIA\",\"lang\":\"hy\",\"languages\":\"hy\",\"lfmt\":\"%N%n%O%n%A%n%Z%n%C%n%S\",\"fmt\":\"%N%n%O%n%A%n%Z%n%C%n%S\"}");
     map.put("AO", "{\"name\":\"ANGOLA\"}");
     map.put("AQ", "{\"name\":\"ANTARCTICA\"}");
     map.put("AR", "{\"name\":\"ARGENTINA\",\"lang\":\"es\",\"languages\":\"es\",\"fmt\":\"%N%n%O%n%A%n%Z %C%n%S\",\"upper\":\"ACZ\"}");
     map.put("AS", "{\"name\":\"AMERICAN SAMOA\",\"fmt\":\"%N%n%O%n%A%n%C %S %Z\",\"require\":\"ACSZ\",\"upper\":\"ACNOS\",\"state_name_type\":\"state\",\"zip_name_type\":\"zip\"}");
     map.put("AT", "{\"name\":\"AUSTRIA\",\"fmt\":\"%O%n%N%n%A%n%Z %C\",\"require\":\"ACZ\"}");
-    map.put("AU", "{\"name\":\"AUSTRALIA\",\"lang\":\"en\",\"languages\":\"en\",\"fmt\":\"%O%n%N%n%A%n%C %S %Z\",\"require\":\"ACSZ\",\"upper\":\"CS\",\"state_name_type\":\"state\"}");
+    map.put("AU", "{\"name\":\"AUSTRALIA\",\"lang\":\"en\",\"languages\":\"en\",\"fmt\":\"%O%n%N%n%A%n%C %S %Z\",\"require\":\"ACSZ\",\"upper\":\"CS\",\"locality_name_type\":\"suburb\",\"state_name_type\":\"state\"}");
     map.put("AW", "{\"name\":\"ARUBA\"}");
     map.put("AX", "{\"name\":\"FINLAND\",\"fmt\":\"%O%n%N%n%A%nAX-%Z %C%nÅLAND\",\"require\":\"ACZ\",\"postprefix\":\"AX-\"}");
     map.put("AZ", "{\"name\":\"AZERBAIJAN\",\"fmt\":\"%N%n%O%n%A%nAZ %Z %C\",\"postprefix\":\"AZ \"}");
@@ -60,7 +60,7 @@ public final class RegionDataConstants {
     map.put("BQ", "{\"name\":\"BONAIRE, SINT EUSTATIUS, AND SABA\"}");
     map.put("BR", "{\"name\":\"BRAZIL\",\"lang\":\"pt\",\"languages\":\"pt\",\"fmt\":\"%O%n%N%n%A%n%D%n%C-%S%n%Z\",\"require\":\"ASCZ\",\"upper\":\"CS\",\"sublocality_name_type\":\"neighborhood\",\"state_name_type\":\"state\",\"width_overrides\":\"%C:L%S:S\"}");
     map.put("BS", "{\"name\":\"BAHAMAS\",\"lang\":\"en\",\"languages\":\"en\",\"fmt\":\"%N%n%O%n%A%n%C, %S\",\"state_name_type\":\"island\"}");
-    map.put("BT", "{\"name\":\"BHUTAN\"}");
+    map.put("BT", "{\"name\":\"BHUTAN\",\"fmt\":\"%N%n%O%n%A%n%C %Z\"}");
     map.put("BV", "{\"name\":\"BOUVET ISLAND\"}");
     map.put("BW", "{\"name\":\"BOTSWANA\"}");
     map.put("BY", "{\"name\":\"BELARUS\",\"fmt\":\"%S%n%Z %C %X%n%A%n%O%n%N\"}");
@@ -184,7 +184,7 @@ public final class RegionDataConstants {
     map.put("MW", "{\"name\":\"MALAWI\",\"fmt\":\"%N%n%O%n%A%n%C %X\"}");
     map.put("MX", "{\"name\":\"MEXICO\",\"lang\":\"es\",\"languages\":\"es\",\"fmt\":\"%N%n%O%n%A%n%D%n%Z %C, %S\",\"require\":\"ACZ\",\"upper\":\"CSZ\",\"sublocality_name_type\":\"neighborhood\",\"state_name_type\":\"state\",\"width_overrides\":\"%S:S\"}");
     map.put("MY", "{\"name\":\"MALAYSIA\",\"lang\":\"ms\",\"languages\":\"ms\",\"fmt\":\"%N%n%O%n%A%n%D%n%Z %C%n%S\",\"require\":\"ACZ\",\"upper\":\"CS\",\"sublocality_name_type\":\"village_township\",\"state_name_type\":\"state\"}");
-    map.put("MZ", "{\"name\":\"MOZAMBIQUE\"}");
+    map.put("MZ", "{\"name\":\"MOZAMBIQUE\",\"fmt\":\"%N%n%O%n%A%n%Z %C\"}");
     map.put("NA", "{\"name\":\"NAMIBIA\"}");
     map.put("NC", "{\"name\":\"NEW CALEDONIA\",\"fmt\":\"%O%n%N%n%A%n%Z %C %X\",\"require\":\"ACZ\",\"upper\":\"ACX\"}");
     map.put("NE", "{\"name\":\"NIGER\",\"fmt\":\"%N%n%O%n%A%n%Z %C\"}");
@@ -199,7 +199,7 @@ public final class RegionDataConstants {
     map.put("NZ", "{\"name\":\"NEW ZEALAND\",\"fmt\":\"%N%n%O%n%A%n%D%n%C %Z\",\"require\":\"ACZ\"}");
     map.put("OM", "{\"name\":\"OMAN\",\"fmt\":\"%N%n%O%n%A%n%Z%n%C\"}");
     map.put("PA", "{\"name\":\"PANAMA (REP.)\",\"fmt\":\"%N%n%O%n%A%n%C%n%S\",\"upper\":\"CS\"}");
-    map.put("PE", "{\"name\":\"PERU\"}");
+    map.put("PE", "{\"name\":\"PERU\",\"fmt\":\"%N%n%O%n%A%n%C %Z%n%S\"}");
     map.put("PF", "{\"name\":\"FRENCH POLYNESIA\",\"fmt\":\"%N%n%O%n%A%n%Z %C %S\",\"require\":\"ACSZ\",\"upper\":\"CS\",\"state_name_type\":\"island\"}");
     map.put("PG", "{\"name\":\"PAPUA NEW GUINEA\",\"fmt\":\"%N%n%O%n%A%n%C %Z %S\",\"require\":\"ACS\"}");
     map.put("PH", "{\"name\":\"PHILIPPINES\",\"lang\":\"en\",\"languages\":\"en\",\"fmt\":\"%N%n%O%n%A%n%D, %C%n%Z %S\"}");
@@ -237,7 +237,7 @@ public final class RegionDataConstants {
     map.put("SV", "{\"name\":\"EL SALVADOR\",\"lang\":\"es\",\"languages\":\"es\",\"fmt\":\"%N%n%O%n%A%n%Z-%C%n%S\",\"require\":\"ACS\",\"upper\":\"CSZ\"}");
     map.put("SX", "{\"name\":\"SINT MAARTEN\"}");
     map.put("SZ", "{\"name\":\"SWAZILAND\",\"fmt\":\"%N%n%O%n%A%n%C%n%Z\",\"upper\":\"ACZ\"}");
-    map.put("TA", "{\"name\":\"TRISTAN DA CUNHA\"}");
+    map.put("TA", "{\"name\":\"TRISTAN DA CUNHA\",\"fmt\":\"%N%n%O%n%A%n%C%n%Z\"}");
     map.put("TC", "{\"name\":\"TURKS AND CAICOS ISLANDS\",\"fmt\":\"%N%n%O%n%A%n%X%n%C%n%Z\",\"require\":\"ACZ\",\"upper\":\"CZ\"}");
     map.put("TD", "{\"name\":\"CHAD\"}");
     map.put("TF", "{\"name\":\"FRENCH SOUTHERN TERRITORIES\"}");
@@ -261,7 +261,7 @@ public final class RegionDataConstants {
     map.put("UY", "{\"name\":\"URUGUAY\",\"lang\":\"es\",\"languages\":\"es\",\"fmt\":\"%N%n%O%n%A%n%Z %C %S\",\"upper\":\"CS\"}");
     map.put("UZ", "{\"name\":\"UZBEKISTAN\",\"fmt\":\"%N%n%O%n%A%n%Z %C%n%S\",\"upper\":\"CS\"}");
     map.put("VA", "{\"name\":\"VATICAN\",\"fmt\":\"%N%n%O%n%A%n%Z %C\"}");
-    map.put("VC", "{\"name\":\"SAINT VINCENT AND THE GRENADINES (ANTILLES)\"}");
+    map.put("VC", "{\"name\":\"SAINT VINCENT AND THE GRENADINES (ANTILLES)\",\"fmt\":\"%N%n%O%n%A%n%C %Z\"}");
     map.put("VE", "{\"name\":\"VENEZUELA\",\"lang\":\"es\",\"languages\":\"es\",\"fmt\":\"%N%n%O%n%A%n%C %Z, %S\",\"require\":\"ACS\",\"upper\":\"CS\",\"state_name_type\":\"state\"}");
     map.put("VG", "{\"name\":\"VIRGIN ISLANDS (BRITISH)\",\"fmt\":\"%N%n%O%n%A%n%C%n%Z\",\"require\":\"A\"}");
     map.put("VI", "{\"name\":\"VIRGIN ISLANDS (U.S.)\",\"fmt\":\"%N%n%O%n%A%n%C %S %Z\",\"require\":\"ACSZ\",\"upper\":\"ACNOS\",\"state_name_type\":\"state\",\"zip_name_type\":\"zip\"}");

--- a/cpp/src/region_data_constants.cc
+++ b/cpp/src/region_data_constants.cc
@@ -40,6 +40,7 @@ namespace {
 std::map<std::string, std::string> InitRegionData() {
   std::map<std::string, std::string> region_data;
   region_data.insert(std::make_pair("AC", "{"
+      "\"fmt\":\"%N%n%O%n%A%n%C%n%Z\","
       "\"zipex\":\"ASCN 1ZZ\","
       "\"languages\":\"en\""
       "}"));
@@ -57,6 +58,7 @@ std::map<std::string, std::string> InitRegionData() {
       "\"languages\":\"ar\""
       "}"));
   region_data.insert(std::make_pair("AF", "{"
+      "\"fmt\":\"%N%n%O%n%A%n%C%n%Z\","
       "\"zipex\":\"1001,2601,3801\","
       "\"posturl\":\"http://afghanpost.gov.af/Postal%20Code/\","
       "\"languages\":\"fa~ps\""
@@ -66,10 +68,12 @@ std::map<std::string, std::string> InitRegionData() {
       "\"languages\":\"en\""
       "}"));
   region_data.insert(std::make_pair("AI", "{"
+      "\"fmt\":\"%N%n%O%n%A%n%C%n%Z\","
       "\"zipex\":\"2640\","
       "\"languages\":\"en\""
       "}"));
   region_data.insert(std::make_pair("AL", "{"
+      "\"fmt\":\"%N%n%O%n%A%n%Z%n%C\","
       "\"zipex\":\"1001,1017,3501\","
       "\"languages\":\"sq\""
       "}"));
@@ -110,6 +114,7 @@ std::map<std::string, std::string> InitRegionData() {
       "\"fmt\":\"%O%n%N%n%A%n%C %S %Z\","
       "\"require\":\"ACSZ\","
       "\"state_name_type\":\"state\","
+      "\"locality_name_type\":\"suburb\","
       "\"zipex\":\"2060,3171,6430,4000,4006,3001\","
       "\"posturl\":\"http://www1.auspost.com.au/postcodes/\","
       "\"languages\":\"en\""
@@ -215,6 +220,7 @@ std::map<std::string, std::string> InitRegionData() {
       "\"languages\":\"en\""
       "}"));
   region_data.insert(std::make_pair("BT", "{"
+      "\"fmt\":\"%N%n%O%n%A%n%C %Z\","
       "\"zipex\":\"11001,31101,35003\","
       "\"posturl\":\"http://www.bhutanpost.com.bt/postcode/postcode.php\","
       "\"languages\":\"dz\""
@@ -907,6 +913,7 @@ std::map<std::string, std::string> InitRegionData() {
       "\"languages\":\"ms\""
       "}"));
   region_data.insert(std::make_pair("MZ", "{"
+      "\"fmt\":\"%N%n%O%n%A%n%Z %C\","
       "\"zipex\":\"1102,1119,3212\","
       "\"languages\":\"pt\""
       "}"));
@@ -991,6 +998,7 @@ std::map<std::string, std::string> InitRegionData() {
       "\"languages\":\"es\""
       "}"));
   region_data.insert(std::make_pair("PE", "{"
+      "\"fmt\":\"%N%n%O%n%A%n%C %Z%n%S\","
       "\"zipex\":\"LIMA 23,LIMA 42,CALLAO 2,02001\","
       "\"posturl\":\"http://www.serpost.com.pe/cpostal/codigo\","
       "\"languages\":\"es~qu\""
@@ -1206,6 +1214,7 @@ std::map<std::string, std::string> InitRegionData() {
       "\"languages\":\"en~ss\""
       "}"));
   region_data.insert(std::make_pair("TA", "{"
+      "\"fmt\":\"%N%n%O%n%A%n%C%n%Z\","
       "\"zipex\":\"TDCU 1ZZ\","
       "\"languages\":\"en\""
       "}"));
@@ -1333,6 +1342,7 @@ std::map<std::string, std::string> InitRegionData() {
       "\"languages\":\"it~la\""
       "}"));
   region_data.insert(std::make_pair("VC", "{"
+      "\"fmt\":\"%N%n%O%n%A%n%C %Z\","
       "\"zipex\":\"VC0100,VC0110,VC0400\","
       "\"posturl\":\"http://www.svgpost.gov.vc/\?option=com_content&view=article&id=3&Itemid=16\","
       "\"languages\":\"en\""

--- a/cpp/src/rule.cc
+++ b/cpp/src/rule.cc
@@ -98,9 +98,11 @@ NameMessageIdMap InitLocalityMessageIds() {
   message_ids.insert(std::make_pair(
       "city", IDS_LIBADDRESSINPUT_LOCALITY_LABEL));
   message_ids.insert(std::make_pair(
+      "district", IDS_LIBADDRESSINPUT_DISTRICT));
+  message_ids.insert(std::make_pair(
       "post_town", IDS_LIBADDRESSINPUT_POST_TOWN));
   message_ids.insert(std::make_pair(
-      "district", IDS_LIBADDRESSINPUT_DISTRICT));
+      "suburb", IDS_LIBADDRESSINPUT_SUBURB));
   return message_ids;
 }
 


### PR DESCRIPTION
* Adds "suburb" as a locality name label and uses it for Australia. Note this already existed as a string to be translated before.
* Added post-codes to the format string for countries where we had the information
* Added a "province" field to Peru.

Fixes issue #46 