### PR TITLE
Missing escapes for backslashes in fakeRequestApi

### DIFF
--- a/common/src/test/java/com/google/i18n/addressinput/common/CacheDataTest.java
+++ b/common/src/test/java/com/google/i18n/addressinput/common/CacheDataTest.java
@@ -143,7 +143,7 @@ public class CacheDataTest {
         + "\"fmt\":\"%N%n%O%n%A%n%C %S %Z\","
         + "\"require\":\"ACSZ\","
         + "\"upper\":\"ACNOSZ\","
-        + "\"zip\":\"[A-Z]\\d[A-Z][ ]?\\d[A-Z]\\d\","
+        + "\"zip\":\"[A-Z]\\\\d[A-Z][ ]?\\\\d[A-Z]\\\\d\","
         + "\"zipex\":\"H3Z 2Y7,V8X 3X4\","
         + "\"posturl\":\"http://www.canadapost.ca\","
         + "\"sub_keys\":\"AB~BC~YT\","


### PR DESCRIPTION
The payload in fakeRequestApi should match what the API returns, which is double-backslash. But in Java you need to escape backslashes, which makes four backslashes. Newer versions of org.json library actually fails parsing the string with "Invalid test JSON data" error.