### PR TITLE
Change grit submodule URL, update readme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "externals/grit"]
 	path = externals/grit
-	url = https://chromium.googlesource.com/external/grit-i18n
+	url = https://chromium.googlesource.com/chromium/src/tools/grit/
 [submodule "externals/rapidjson"]
 	path = externals/rapidjson
 	url = https://github.com/miloyip/rapidjson.git

--- a/README.md
+++ b/README.md
@@ -18,16 +18,10 @@ values.
 
 ## C++
 
-The C++ library (in very portable C++03) of _libaddressinput_ is the backend for
-[requestAutocomplete()](http://www.html5rocks.com/en/tutorials/forms/requestautocomplete/)
-in [Chromium](http://www.chromium.org/Home). The source code for that is a good
-example of how to use this library to implement a complex feature in a real
-application:
+The C++ library (in very portable C++03) of _libaddressinput_ is used in address-related
+projects in [Chromium](http://www.chromium.org/Home).
 
-https://src.chromium.org/viewvc/chrome/trunk/src/third_party/libaddressinput/
 https://chromium.googlesource.com/chromium/src/+/master/third_party/libaddressinput/
-
-Video: [Easy International Checkout with Chrome](https://www.youtube.com/watch?v=ljYeHwGgzQk)
 
 ## Java
 


### PR DESCRIPTION
This updates the "externals/grit" submodule URL because the repository moved.

See updated grit readme [here](https://chromium.googlesource.com/external/grit-i18n/+/7af1a69da7bbcba0941b5b55be5365a59f87a932/README).

Also tweaked the README file to no longer mention requestAutocomplete (dead).