### PR TITLE
Update Gradle plugin for Android to 2.3.0

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -20,7 +20,7 @@ buildscript {
         mavenLocal()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.1.0'
+        classpath 'com.android.tools.build:gradle:2.3.0'
     }
 }
 
@@ -54,7 +54,7 @@ android {
      * The obvious way to fix this would be allow wildcards (ie, "22.+") but
      * Android have explicitly said that they won't do this.
      */
-    compileSdkVersion 22
-    buildToolsVersion '21.1.2'
+    compileSdkVersion 25
+    buildToolsVersion '25.0.3'
 }
 

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -5,7 +5,7 @@
 
     <uses-sdk
         android:minSdkVersion="9"
-        android:targetSdkVersion="22" />
+        android:targetSdkVersion="25" />
     <application/>
 
 </manifest>

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -20,7 +20,7 @@ buildscript {
         mavenLocal()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.1.0'
+        classpath 'com.android.tools.build:gradle:2.3.0'
     }
 }
 


### PR DESCRIPTION
```
libaddressinput (salvatoret/gradle-2.3)$ gradle test
WARNING: WARNING: Dependency org.json:json:20090211 is ignored for debug as it may be conflicting with the internal version provided by Android.
         In case of problem, please repackage it with jarjar to change the class packages
WARNING: WARNING: Dependency org.json:json:20090211 is ignored for debug as it may be conflicting with the internal version provided by Android.
         In case of problem, please repackage it with jarjar to change the class packages
WARNING: WARNING: Dependency org.json:json:20090211 is ignored for release as it may be conflicting with the internal version provided by Android.
         In case of problem, please repackage it with jarjar to change the class packages
WARNING: WARNING: Dependency org.json:json:20090211 is ignored for release as it may be conflicting with the internal version provided by Android.
         In case of problem, please repackage it with jarjar to change the class packages
WARNING: WARNING: Dependency org.json:json:20090211 is ignored for debugAndroidTest as it may be conflicting with the internal version provided by Android.
         In case of problem, please repackage it with jarjar to change the class packages
WARNING: WARNING: Dependency org.json:json:20090211 is ignored for debugAndroidTest as it may be conflicting with the internal version provided by Android.
         In case of problem, please repackage it with jarjar to change the class packages
:android:preBuild UP-TO-DATE
:android:preDebugBuild UP-TO-DATE
:android:checkDebugManifest
:common:compileJava
warning: [options] bootstrap class path not set in conjunction with -source 1.7
Note: Some input files use or override a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
1 warning
:common:processResources NO-SOURCE
:common:classes
:common:jar
:android:prepareDebugDependencies
:android:compileDebugAidl
:android:compileDebugRenderscript UP-TO-DATE
:android:generateDebugBuildConfig
:android:generateDebugResValues UP-TO-DATE
:android:generateDebugResources UP-TO-DATE
:android:packageDebugResources
:android:processDebugManifest
:android:processDebugResources
:android:generateDebugSources
:android:incrementalDebugJavaCompilationSafeguard
:android:javaPreCompileDebug
:android:compileDebugJavaWithJavac
:android:compileDebugJavaWithJavac - is not incremental (e.g. outputs have changed, no previous execution, etc.).
Note: /Users/sal/Development/libaddressinput/android/src/main/java/com/android/i18n/addressinput/AddressWidget.java uses or overrides a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
:android:incrementalDebugUnitTestJavaCompilationSafeguard NO-SOURCE
:android:javaPreCompileDebugUnitTest
:android:preDebugUnitTestBuild UP-TO-DATE
:android:prepareDebugUnitTestDependencies
:android:compileDebugUnitTestJavaWithJavac NO-SOURCE
:android:processDebugJavaRes NO-SOURCE
:android:processDebugUnitTestJavaRes NO-SOURCE
:android:compileDebugUnitTestSources UP-TO-DATE
:android:mockableAndroidJar UP-TO-DATE
:android:assembleDebugUnitTest UP-TO-DATE
:android:testDebugUnitTest NO-SOURCE
:android:preReleaseBuild UP-TO-DATE
:android:checkReleaseManifest
:android:prepareReleaseDependencies
:android:compileReleaseAidl
:android:compileReleaseRenderscript
:android:generateReleaseBuildConfig
:android:generateReleaseResValues
:android:generateReleaseResources
:android:packageReleaseResources
:android:processReleaseManifest
:android:processReleaseResources
:android:generateReleaseSources
:android:incrementalReleaseJavaCompilationSafeguard
:android:javaPreCompileRelease
:android:compileReleaseJavaWithJavac
:android:compileReleaseJavaWithJavac - is not incremental (e.g. outputs have changed, no previous execution, etc.).
Note: /Users/sal/Development/libaddressinput/android/src/main/java/com/android/i18n/addressinput/AddressWidget.java uses or overrides a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
:android:incrementalReleaseUnitTestJavaCompilationSafeguard NO-SOURCE
:android:javaPreCompileReleaseUnitTest
:android:preReleaseUnitTestBuild UP-TO-DATE
:android:prepareReleaseUnitTestDependencies
:android:compileReleaseUnitTestJavaWithJavac NO-SOURCE
:android:processReleaseJavaRes NO-SOURCE
:android:processReleaseUnitTestJavaRes NO-SOURCE
:android:compileReleaseUnitTestSources UP-TO-DATE
:android:assembleReleaseUnitTest UP-TO-DATE
:android:testReleaseUnitTest NO-SOURCE
:android:test UP-TO-DATE
:common:compileTestJava
warning: [options] bootstrap class path not set in conjunction with -source 1.7
Note: /Users/sal/Development/libaddressinput/common/src/test/java/com/google/i18n/addressinput/common/FormatInterpreterTest.java uses or overrides a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
1 warning
:common:processTestResources
:common:testClasses
:common:test
Running test: Test testBuilderDoesNotReindexFieldsOnRemoval(com.google.i18n.addressinput.common.AddressDataTest)
Running test: Test testAddressLineNormalisationExcludesNull(com.google.i18n.addressinput.common.AddressDataTest)
Running test: Test testAddressLineNormalisationComplex(com.google.i18n.addressinput.common.AddressDataTest)
Running test: Test testAddressLineNormalisationSplitsOnNewline(com.google.i18n.addressinput.common.AddressDataTest)
Running test: Test testAddressLineSimple(com.google.i18n.addressinput.common.AddressDataTest)
Running test: Test testManyAddressLines(com.google.i18n.addressinput.common.AddressDataTest)
Running test: Test testSetSingleAddressLine(com.google.i18n.addressinput.common.AddressDataTest)
Running test: Test testAddressLineNormalisationExcludesEmptyOrWhitespace(com.google.i18n.addressinput.common.AddressDataTest)
Running test: Test testAddressLineNormalisationManyEmbeddedLines(com.google.i18n.addressinput.common.AddressDataTest)
Running test: Test testSetLanguageCode(com.google.i18n.addressinput.common.AddressDataTest)
Running test: Test testAddressLineNormalisationTrimsWhitespace(com.google.i18n.addressinput.common.AddressDataTest)
Running test: Test testNoAdminArea(com.google.i18n.addressinput.common.AddressDataTest)
Running test: Test testBuilderSplitsLinesLazily(com.google.i18n.addressinput.common.AddressDataTest)
Running test: Test testGetWidthTypeForCountry(com.google.i18n.addressinput.common.AddressFieldTest)
Running test: Test testGetWidthTypeForPostalCode(com.google.i18n.addressinput.common.AddressFieldTest)
Running test: Test testOf(com.google.i18n.addressinput.common.AddressFieldTest)
Running test: Test testGetChar(com.google.i18n.addressinput.common.AddressFieldTest)
Running test: Test testGetWidthTypeWithOverride(com.google.i18n.addressinput.common.AddressFieldTest)
Running test: Test testAddError(com.google.i18n.addressinput.common.AddressProblemsTest)
Running test: Test testEmptyErrorList(com.google.i18n.addressinput.common.AddressProblemsTest)
Running test: Test testParseAllData(com.google.i18n.addressinput.common.AddressVerificationDataTest)
Running test: Test testLoadingCountries(com.google.i18n.addressinput.common.AddressVerificationDataTest)
Running test: Test testCaFrenchData(com.google.i18n.addressinput.common.AddressVerificationDataTest)
Running test: Test testBackSlashUnEscaped(com.google.i18n.addressinput.common.AddressVerificationDataTest)
Running test: Test testCaData(com.google.i18n.addressinput.common.AddressVerificationDataTest)
Running test: Test testExampleData(com.google.i18n.addressinput.common.AddressVerificationDataTest)
Running test: Test testUsData(com.google.i18n.addressinput.common.AddressVerificationDataTest)
Running test: Test testSimpleFetching(com.google.i18n.addressinput.common.CacheDataTest)
Running test: Test testTimeoutKey(com.google.i18n.addressinput.common.CacheDataTest)
Running test: Test testRecursiveFetchFromCallback(com.google.i18n.addressinput.common.CacheDataTest)
Running test: Test testJsonConstructorTruncatedProperString(com.google.i18n.addressinput.common.CacheDataTest)
Running test: Test testFetchingOneKeyManyTimes(com.google.i18n.addressinput.common.CacheDataTest)
Running test: Test testJsonConstructor(com.google.i18n.addressinput.common.CacheDataTest)
Running test: Test testSetUrl(com.google.i18n.addressinput.common.CacheDataTest)
Running test: Test testInvalidKey(com.google.i18n.addressinput.common.CacheDataTest)
Running test: Test testPrefetchCountry(com.google.i18n.addressinput.common.ClientDataTest)
Running test: Test testFallbackToBuiltInData(com.google.i18n.addressinput.common.ClientDataTest)
Running test: Test testGetRequiresLoading(com.google.i18n.addressinput.common.ClientDataTest)
Running test: Test testCacheUpdatesBetweenBeginAndEndCallback(com.google.i18n.addressinput.common.ClientDataTest)
Running test: Test testGetAlreadyCached(com.google.i18n.addressinput.common.ClientDataTest)
Running test: Test testGetBadDataKey(com.google.i18n.addressinput.common.ClientDataTest)
Running test: Test testEmptyPostalCodeReportedAsGoodFormat(com.google.i18n.addressinput.common.FieldVerifierTest)
Running test: Test testNoSideEffects(com.google.i18n.addressinput.common.FieldVerifierTest)
Running test: Test testUnitedStatesWithIllegalField(com.google.i18n.addressinput.common.FieldVerifierTest)
Running test: Test testJapanLatinInvalidAdmin(com.google.i18n.addressinput.common.FieldVerifierTest)
Running test: Test testUnitedStatesOk(com.google.i18n.addressinput.common.FieldVerifierTest)
Running test: Test testGermanAddress(com.google.i18n.addressinput.common.FieldVerifierTest)
Running test: Test testUnrecognizedFormatCheckWithNoState_US(com.google.i18n.addressinput.common.FieldVerifierTest)
Running test: Test testCanadaMixedCasePostcode(com.google.i18n.addressinput.common.FieldVerifierTest)
Running test: Test testJapan(com.google.i18n.addressinput.common.FieldVerifierTest)
Running test: Test testNoCountryProvided(com.google.i18n.addressinput.common.FieldVerifierTest)
Running test: Test testIrishAddress(com.google.i18n.addressinput.common.FieldVerifierTest)
Running test: Test testHongKongNoStreetInEnglish(com.google.i18n.addressinput.common.FieldVerifierTest)
Running test: Test testBahamas(com.google.i18n.addressinput.common.FieldVerifierTest)
Running test: Test testChinaTaiwanOk(com.google.i18n.addressinput.common.FieldVerifierTest)
Running test: Test testHongKongInvalidDistrictInEnglish(com.google.i18n.addressinput.common.FieldVerifierTest)
Running test: Test testMultipleAddressLines(com.google.i18n.addressinput.common.FieldVerifierTest)
Running test: Test testChinaTaiwanUnknownDistrict(com.google.i18n.addressinput.common.FieldVerifierTest)
Running test: Test testChinaOk(com.google.i18n.addressinput.common.FieldVerifierTest)
Running test: Test testChinaPostalCodeMismatchingFormat(com.google.i18n.addressinput.common.FieldVerifierTest)
Running test: Test testUnitedStatesZipMismatch(com.google.i18n.addressinput.common.FieldVerifierTest)
Running test: Test testElSalvador(com.google.i18n.addressinput.common.FieldVerifierTest)
Running test: Test testStreetVerification(com.google.i18n.addressinput.common.FieldVerifierTest)
Running test: Test testChinaPostalCodeBadFormat(com.google.i18n.addressinput.common.FieldVerifierTest)
Running test: Test testFieldVerifierUsesRegionDataConstantsForFmtAndRequire(com.google.i18n.addressinput.common.FieldVerifierTest)
Running test: Test testJapanLatin(com.google.i18n.addressinput.common.FieldVerifierTest)
Running test: Test testFranceInvalidPostcode(com.google.i18n.addressinput.common.FieldVerifierTest)
Running test: Test testUnitedStatesNotOk(com.google.i18n.addressinput.common.FieldVerifierTest)
Running test: Test testGetEnvelopeAddressIncompleteAddress(com.google.i18n.addressinput.common.FormatInterpreterTest)
Running test: Test testIterateTwLatinAddressFields(com.google.i18n.addressinput.common.FormatInterpreterTest)
Running test: Test testUsEnvelopeAddress(com.google.i18n.addressinput.common.FormatInterpreterTest)
Running test: Test testGetEnvelopeAddressLeadingPostPrefix(com.google.i18n.addressinput.common.FormatInterpreterTest)
Running test: Test testGetWidthOverride_goodData(com.google.i18n.addressinput.common.FormatInterpreterTest)
Running test: Test testSvAddress(com.google.i18n.addressinput.common.FormatInterpreterTest)
Running test: Test testOverrideFieldOrder(com.google.i18n.addressinput.common.FormatInterpreterTest)
Running test: Test testGetWidthOverride_skipTooLongKeys(com.google.i18n.addressinput.common.FormatInterpreterTest)
Running test: Test testTwEnvelopeAddress(com.google.i18n.addressinput.common.FormatInterpreterTest)
Running test: Test testGetEnvelopeAddress_MissingFields_LiteralsBetweenFields(com.google.i18n.addressinput.common.FormatInterpreterTest)
Running test: Test testIterateUsAddressFields(com.google.i18n.addressinput.common.FormatInterpreterTest)
Running test: Test testGetEnvelopeAddress_MissingFields_LiteralsOnSeparateLine(com.google.i18n.addressinput.common.FormatInterpreterTest)
Running test: Test testIterateVuAddressFields(com.google.i18n.addressinput.common.FormatInterpreterTest)
Running test: Test testGetEnvelopeAddress_MissingFields_DuplicateField(com.google.i18n.addressinput.common.FormatInterpreterTest)
Running test: Test testGetWidthOverride_badData(com.google.i18n.addressinput.common.FormatInterpreterTest)
Running test: Test testGetWidthOverride_singleOverride(com.google.i18n.addressinput.common.FormatInterpreterTest)
Running test: Test testGetEnvelopeAddress_MissingFields_LiteralBeforeField(com.google.i18n.addressinput.common.FormatInterpreterTest)
Running test: Test testGetEnvelopeAddressEmptyAddress(com.google.i18n.addressinput.common.FormatInterpreterTest)
Running test: Test testRequestDataForCountry(com.google.i18n.addressinput.common.FormControllerTest)
Running test: Test testRequestDataForAddress(com.google.i18n.addressinput.common.FormControllerTest)
Running test: Test testRequestDataForBadAddress(com.google.i18n.addressinput.common.FormControllerTest)
Running test: Test testBlacklistedRegions(com.google.i18n.addressinput.common.FormOptionsTest)
Running test: Test testReadonlyField(com.google.i18n.addressinput.common.FormOptionsTest)
Running test: Test testHiddenField(com.google.i18n.addressinput.common.FormOptionsTest)
Running test: Test testCustomFieldOrder(com.google.i18n.addressinput.common.FormOptionsTest)
Running test: Test testCustomFieldOrderEmptyList(com.google.i18n.addressinput.common.FormOptionsTest)
Running test: Test testCustomFieldOrderDuplicateFields(com.google.i18n.addressinput.common.FormOptionsTest)
Running test: Test testMergeData(com.google.i18n.addressinput.common.JsoMapTest)
Running test: Test testGet(com.google.i18n.addressinput.common.JsoMapTest)
Running test: Test testMap(com.google.i18n.addressinput.common.JsoMapTest)
Running test: Test testPut(com.google.i18n.addressinput.common.JsoMapTest)
Running test: Test testCreateEmptyJsoMap(com.google.i18n.addressinput.common.JsoMapTest)
Running test: Test testGetKeys(com.google.i18n.addressinput.common.JsoMapTest)
Running test: Test testContainsKey(com.google.i18n.addressinput.common.JsoMapTest)
Running test: Test testDelKey(com.google.i18n.addressinput.common.JsoMapTest)
Running test: Test testBuildJsoMap(com.google.i18n.addressinput.common.JsoMapTest)
Running test: Test testGetInt(com.google.i18n.addressinput.common.JsoMapTest)
Running test: Test testGetObj(com.google.i18n.addressinput.common.JsoMapTest)
Running test: Test testPutInt(com.google.i18n.addressinput.common.JsoMapTest)
Running test: Test testPutObj(com.google.i18n.addressinput.common.JsoMapTest)
Running test: Test testString(com.google.i18n.addressinput.common.JsoMapTest)
Running test: Test testDataKeys(com.google.i18n.addressinput.common.LookupKeyTest)
Running test: Test testInvalidKeyTypeWillFail(com.google.i18n.addressinput.common.LookupKeyTest)
Running test: Test testExampleRootKeys(com.google.i18n.addressinput.common.LookupKeyTest)
Running test: Test testLanguageKeysRoundTrip(com.google.i18n.addressinput.common.LookupKeyTest)
Running test: Test testWeDoNotVerifyKeyName(com.google.i18n.addressinput.common.LookupKeyTest)
Running test: Test testHash(com.google.i18n.addressinput.common.LookupKeyTest)
Running test: Test testGetKeyForUpperLevelFieldWithExampleKey(com.google.i18n.addressinput.common.LookupKeyTest)
Running test: Test testGetValueForUpperLevelField(com.google.i18n.addressinput.common.LookupKeyTest)
Running test: Test testGetKeyForUpperLevelFieldWithDataKey(com.google.i18n.addressinput.common.LookupKeyTest)
Running test: Test testGetParentKeyStartingFromAddressWithLanguageSpecified(com.google.i18n.addressinput.common.LookupKeyTest)
Running test: Test testNonUsAddress(com.google.i18n.addressinput.common.LookupKeyTest)
Running test: Test testRootKey(com.google.i18n.addressinput.common.LookupKeyTest)
Running test: Test testGetParentKeyStartingFromAddress(com.google.i18n.addressinput.common.LookupKeyTest)
Running test: Test testKeyStringWithMultipleExtraTokensIsConsideredPartOfName(com.google.i18n.addressinput.common.LookupKeyTest)
Running test: Test testExampleKeys(com.google.i18n.addressinput.common.LookupKeyTest)
Running test: Test testKeyWithWrongScriptType(com.google.i18n.addressinput.common.LookupKeyTest)
Running test: Test testGetValueForUpperLevelFieldInvalid(com.google.i18n.addressinput.common.LookupKeyTest)
Running test: Test testFallbackToCountry(com.google.i18n.addressinput.common.LookupKeyTest)
Running test: Test testKeyStringWithAdditionalTokenIsConsideredPartOfName(com.google.i18n.addressinput.common.LookupKeyTest)
Running test: Test testDataLoad(com.google.i18n.addressinput.common.RegionDataConstantsTest)
Running test: Test testZZRegion(com.google.i18n.addressinput.common.RegionDataConstantsTest)
Running test: Test testBuilderWhitespaceName(com.google.i18n.addressinput.common.RegionDataTest)
Running test: Test testBuilder(com.google.i18n.addressinput.common.RegionDataTest)
Running test: Test testBuilderNoName(com.google.i18n.addressinput.common.RegionDataTest)
Running test: Test testUnitedStates_MultipleProblems(com.google.i18n.addressinput.common.StandardAddressVerifierTest)
Running test: Test testJapanAddress(com.google.i18n.addressinput.common.StandardAddressVerifierTest)
Running test: Test testGermanAddress(com.google.i18n.addressinput.common.StandardAddressVerifierTest)
Running test: Test testUnitedStates_Valid(com.google.i18n.addressinput.common.StandardAddressVerifierTest)
Running test: Test testCustomProblemMap(com.google.i18n.addressinput.common.StandardAddressVerifierTest)
Running test: Test testIrishAddress(com.google.i18n.addressinput.common.StandardAddressVerifierTest)
Running test: Test testChinaTaiwanAddress(com.google.i18n.addressinput.common.StandardAddressVerifierTest)
Running test: Test testUnitedStates_PostalCodeMismatch(com.google.i18n.addressinput.common.StandardAddressVerifierTest)
Running test: Test testUnitedStates_MissingStreetAddress(com.google.i18n.addressinput.common.StandardAddressVerifierTest)
Running test: Test testEmptyPostalCode_Prohibited(com.google.i18n.addressinput.common.StandardAddressVerifierTest)
Running test: Test testChinaAddress(com.google.i18n.addressinput.common.StandardAddressVerifierTest)
Running test: Test testEmptyPostalCode_Allowed(com.google.i18n.addressinput.common.StandardAddressVerifierTest)
Running test: Test testEmptyProblemMap(com.google.i18n.addressinput.common.StandardAddressVerifierTest)
Running test: Test testJapanAddress_Latin(com.google.i18n.addressinput.common.StandardAddressVerifierTest)
Running test: Test testJoinAndSkipNulls(com.google.i18n.addressinput.common.UtilTest)
Running test: Test testBuildNameToKeyMap(com.google.i18n.addressinput.common.UtilTest)
Running test: Test testIsExplicitLatinScript(com.google.i18n.addressinput.common.UtilTest)
Running test: Test testIsExplicitLatinScriptNonLatin(com.google.i18n.addressinput.common.UtilTest)
Running test: Test testGetWidgetCompatibleLanguageCodeThailand(com.google.i18n.addressinput.common.UtilTest)
Running test: Test testTrimToNull(com.google.i18n.addressinput.common.UtilTest)
Running test: Test testGetWidgetCompatibleLanguageCodeNonCjkCountry(com.google.i18n.addressinput.common.UtilTest)
Running test: Test testGetWidgetCompatibleLanguageCodeCjkCountry(com.google.i18n.addressinput.common.UtilTest)
Running test: Test testGetLanguageSubtag(com.google.i18n.addressinput.common.UtilTest)

BUILD SUCCESSFUL

Total time: 3.489 secs
```