### PR TITLE
(AUTOMATIC) opensource update

### DIFF
--- a/cpp/src/address_normalizer.cc
+++ b/cpp/src/address_normalizer.cc
@@ -69,7 +69,7 @@ void AddressNormalizer::Normalize(AddressData* address) const {
 
     const std::vector<std::string>& sub_keys = parent_rule->GetSubKeys();
 
-    for (int i = 0; i < sub_keys.size(); i++) {
+    for (size_t i = 0; i < sub_keys.size(); i++) {
       const std::string& sub_key = sub_keys[i];
       if (!no_match_found_yet)
         break;


### PR DESCRIPTION
Add a fix for the warning treated as an error on Windows.

In the loop for regions in address_normalizer.cc, the loop index was a int. Windows was complaining about a signed/unsigned comparison. The index is now a size_t instead.