### PR TITLE
(AUTOMATIC) opensource update

### DIFF
--- a/cpp/include/libaddressinput/localization.h
+++ b/cpp/include/libaddressinput/localization.h
@@ -78,11 +78,12 @@ class Localization {
   // |post_service_url| is empty, then the error message will not contain a post
   // service URL. The problem should only be one of MISSING_REQUIRED_FIELD,
   // INVALID_FORMAT, or MISMATCHING_VALUE.
-  std::string GetErrorMessageForPostalCode(const AddressData& address,
-                                           AddressProblem problem,
-                                           bool uses_postal_code_as_label,
-                                           std::string postal_code_example,
-                                           std::string post_service_url) const;
+  std::string GetErrorMessageForPostalCode(
+      const AddressData& address,
+      AddressProblem problem,
+      bool uses_postal_code_as_label,
+      const std::string& postal_code_example,
+      const std::string& post_service_url) const;
 
   // The string getter.
   std::string (*get_string_)(int);

--- a/cpp/src/localization.cc
+++ b/cpp/src/localization.cc
@@ -128,8 +128,8 @@ std::string Localization::GetErrorMessageForPostalCode(
     const AddressData& address,
     AddressProblem problem,
     bool uses_postal_code_as_label,
-    std::string postal_code_example,
-    std::string post_service_url) const {
+    const std::string& postal_code_example,
+    const std::string& post_service_url) const {
   int message_id;
   std::vector<std::string> parameters;
   if (problem == MISSING_REQUIRED_FIELD) {

--- a/cpp/src/util/size.h
+++ b/cpp/src/util/size.h
@@ -16,9 +16,30 @@
 #define I18N_ADDRESSINPUT_UTIL_SIZE_H_
 
 #include <cstddef>
+#include <iterator>
 
 namespace i18n {
 namespace addressinput {
+
+// If the C++17 std::size is provided by the standard library then the fallback
+// C++11 implementation must not be used for that would make it ambiguous which
+// one of the two implementations a call should be resolved to.
+//
+// Although libaddressinput.gyp explicitly sets -std=c++11 it's possible that
+// this is overriden at build time to use a newer version of the standard.
+//
+// It's also possible that C++17 std::size is defined even when building for an
+// older version of the standard, which is done in the Microsoft implementation
+// of the C++ Standard Library:
+//
+// https://docs.microsoft.com/en-us/cpp/visual-cpp-language-conformance
+
+#if __cpp_lib_nonmember_container_access >= 201411 || \
+    (_LIBCPP_VERSION >= 1101 && _LIBCPP_STD_VER > 14) || _MSC_VER >= 1900
+
+using std::size;
+
+#else
 
 // A C++11 implementation of the C++17 std::size, copied from the standard:
 // https://isocpp.org/files/papers/n4280.pdf
@@ -27,6 +48,8 @@ template <class T, size_t N>
 constexpr size_t size(const T (&array)[N]) {
   return N;
 }
+
+#endif
 
 }  // namespace addressinput
 }  // namespace i18n


### PR DESCRIPTION
Adds a #if macro to handle the fact that It's also possible that C++17 std::size is defined even when building for an older version of the standard

Small fix to pass const ref of strings instead of pass by value.