### PR TITLE
(AUTOMATIC) opensource update

### DIFF
--- a/android/src/androidTest/AndroidManifest.xml
+++ b/android/src/androidTest/AndroidManifest.xml
@@ -11,18 +11,11 @@
     <!-- Gradle generates an <instrumentation> block during the build process,
          but in order to work with other build systems, that don't do that,
          there must be such a block declared here. -->
-    <instrumentation
-        android:name="android.test.InstrumentationTestRunner"
-        android:targetPackage="com.android.i18n.addressinput.test" />
-
-    <uses-permission android:name="android.permission.INTERNET" />
-
-    <application
-        android:allowBackup="false"
-        android:icon="@android:drawable/sym_def_app_icon" >
-        <uses-library android:name="android.test.runner" />
-        <activity
-            android:name="com.android.i18n.addressinput.testing.TestActivity" />
-    </application>
-
+  <instrumentation android:name="android.test.InstrumentationTestRunner" android:targetPackage="com.android.i18n.addressinput.test"/>
+  <instrumentation android:name="com.google.android.apps.common.testing.testrunner.Google3InstrumentationTestRunner" android:targetPackage="com.android.i18n.addressinput.test"/>
+  <uses-permission android:name="android.permission.INTERNET"/>
+  <application android:allowBackup="false" android:icon="@android:drawable/sym_def_app_icon">
+    <uses-library android:name="android.test.runner"/>
+    <activity android:name="com.android.i18n.addressinput.testing.TestActivity"/>
+  </application>
 </manifest>

--- a/cpp/src/address_ui.cc
+++ b/cpp/src/address_ui.cc
@@ -42,39 +42,39 @@ std::string GetLabelForField(const Localization& localization,
                              int postal_code_name_message_id,
                              int locality_name_message_id,
                              int sublocality_name_message_id) {
-  int messageId;
+  int message_id;
   switch (field) {
     case SORTING_CODE:
       // This needs no translation as it's used only in one locale.
       return "CEDEX";
     case COUNTRY:
-      messageId = IDS_LIBADDRESSINPUT_COUNTRY_OR_REGION_LABEL;
+      message_id = IDS_LIBADDRESSINPUT_COUNTRY_OR_REGION_LABEL;
       break;
     case ADMIN_AREA:
-      messageId = admin_area_name_message_id;
+      message_id = admin_area_name_message_id;
       break;
     case LOCALITY:
-      messageId = locality_name_message_id;
+      message_id = locality_name_message_id;
       break;
     case DEPENDENT_LOCALITY:
-      messageId = sublocality_name_message_id;
+      message_id = sublocality_name_message_id;
       break;
     case POSTAL_CODE:
-      messageId = postal_code_name_message_id;
+      message_id = postal_code_name_message_id;
       break;
     case STREET_ADDRESS:
-      messageId = IDS_LIBADDRESSINPUT_ADDRESS_LINE_1_LABEL;
+      message_id = IDS_LIBADDRESSINPUT_ADDRESS_LINE_1_LABEL;
       break;
     case ORGANIZATION:
-      messageId = IDS_LIBADDRESSINPUT_ORGANIZATION_LABEL;
+      message_id = IDS_LIBADDRESSINPUT_ORGANIZATION_LABEL;
       break;
     case RECIPIENT:
-      messageId = IDS_LIBADDRESSINPUT_RECIPIENT_LABEL;
+      message_id = IDS_LIBADDRESSINPUT_RECIPIENT_LABEL;
       break;
     default:
-      messageId = INVALID_MESSAGE_ID;
+      message_id = INVALID_MESSAGE_ID;
   }
-  return localization.GetString(messageId);
+  return localization.GetString(message_id);
 }
 
 }  // namespace

--- a/cpp/test/testdata_source.cc
+++ b/cpp/test/testdata_source.cc
@@ -26,6 +26,8 @@
 namespace i18n {
 namespace addressinput {
 
+const char kDataFileName[] = TEST_DATA_DIR "/countryinfo.txt";
+
 namespace {
 
 // For historical reasons, normal and aggregated data is here stored in the
@@ -33,9 +35,6 @@ namespace {
 // seem like a good idea to refactor this.
 const char kNormalPrefix = '-';
 const char kAggregatePrefix = '+';
-
-// The name of the test data file.
-const char kDataFileName[] = TEST_DATA_DIR "/countryinfo.txt";
 
 // Each data key begins with this string. Example of a data key:
 //     data/CH/AG
@@ -53,10 +52,9 @@ const size_t kAggregateDataKeyLength =
 
 std::map<std::string, std::string> InitData(const std::string& src_path) {
   std::map<std::string, std::string> data;
-  std::string data_file_name = src_path + kDataFileName;
-  std::ifstream file(data_file_name);
+  std::ifstream file(src_path);
   if (!file.is_open()) {
-    std::cerr << "Error opening \"" << data_file_name << "\"." << std::endl;
+    std::cerr << "Error opening \"" << src_path << "\"." << std::endl;
     std::exit(EXIT_FAILURE);
   }
 
@@ -150,7 +148,7 @@ TestdataSource::TestdataSource(bool aggregate, const std::string& src_path)
     : aggregate_(aggregate), src_path_(src_path) {}
 
 TestdataSource::TestdataSource(bool aggregate)
-    : aggregate_(aggregate) {}
+    : aggregate_(aggregate), src_path_(kDataFileName) {}
 
 TestdataSource::~TestdataSource() {}
 

--- a/cpp/test/testdata_source.h
+++ b/cpp/test/testdata_source.h
@@ -25,20 +25,20 @@
 namespace i18n {
 namespace addressinput {
 
+// The name of the test data file.
+extern const char kDataFileName[];
+
 // Gets address metadata from a text file. Sample usage:
 //    class MyClass {
 //     public:
 //      MyClass(const MyClass&) = delete;
 //      MyClass& operator=(const MyClass&) = delete;
 //
-//      MyClass() : data_ready_(BuildCallback(this, &MyClass::OnDataReady)) {
-//        base::FilePath src_path;
-//        CHECK(PathService::Get(base::DIR_SOURCE_ROOT, &src_path));
-//        source_ = new TestdataSource(/*aggregate=*/true,
-//                                     src_path.value() + '/');
-//      }
+//      MyClass() : data_ready_(BuildCallback(this, &MyClass::OnDataReady)),
+//                  source_(/*aggregate=*/true,
+//                          "path/to/test/data/file") {}
 //
-//      ~MyClass() { delete source_; }
+//      ~MyClass() {}
 //
 //      void GetData(const std::string& key) {
 //        source_->Get(key, *data_ready_);
@@ -53,7 +53,7 @@ namespace addressinput {
 //      }
 //
 //      const std::unique_ptr<const Source::Callback> data_ready_;
-//      const TestdataSource* source_;
+//      const TestdataSource source_;
 //    };
 class TestdataSource : public Source {
  public:
@@ -61,8 +61,10 @@ class TestdataSource : public Source {
   TestdataSource& operator=(const TestdataSource&) = delete;
 
   // Will return aggregate data if |aggregate| is set to true.
+  // This constructor uses a relative path to the test file.
   explicit TestdataSource(bool aggregate);
-  // |src_path| is the root of the source tree.
+
+  // |src_path| is a path to the test data file.
   TestdataSource(bool aggregate, const std::string& src_path);
 
   virtual ~TestdataSource();

--- a/cpp/test/testdata_source_test.cc
+++ b/cpp/test/testdata_source_test.cc
@@ -31,6 +31,7 @@ using i18n::addressinput::BuildCallback;
 using i18n::addressinput::RegionDataConstants;
 using i18n::addressinput::Source;
 using i18n::addressinput::TestdataSource;
+using i18n::addressinput::kDataFileName;
 
 // Tests for TestdataSource object.
 class TestdataSourceTest : public testing::TestWithParam<std::string> {
@@ -41,9 +42,9 @@ class TestdataSourceTest : public testing::TestWithParam<std::string> {
  protected:
   TestdataSourceTest()
       : source_(false),
-        source_with_path_(false, ""),
+        source_with_path_(false, kDataFileName),
         aggregate_source_(true),
-        aggregate_source_with_path_(true, ""),
+        aggregate_source_with_path_(true, kDataFileName),
         success_(false),
         key_(),
         data_(),


### PR DESCRIPTION
Make the countryinfo.txt file accessible outside of libaddressinput for easier testing.

Updates to the android tests manifest.

Minor change to variable names to respect the style guide.