### PR TITLE
Make size.h compatible with libc++ on Windows.

### DIFF
--- a/cpp/src/util/size.h
+++ b/cpp/src/util/size.h
@@ -35,7 +35,8 @@ namespace addressinput {
 // https://docs.microsoft.com/en-us/cpp/visual-cpp-language-conformance
 
 #if __cpp_lib_nonmember_container_access >= 201411 || \
-    (_LIBCPP_VERSION >= 1101 && _LIBCPP_STD_VER > 14) || _MSC_VER >= 1900
+    (_LIBCPP_VERSION >= 1101 && _LIBCPP_STD_VER > 14) || \
+    (!defined(_LIBCPP_STD_VER) && _MSC_VER >= 1900)
 
 using std::size;
 


### PR DESCRIPTION
We cannot solely rely on the value of _MSC_VER when determining
whether the standard library provides a definition of std::size;
we also need to make sure that the standard library is not libc++.